### PR TITLE
fix(maven): remove `<build/>` from parent pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,30 +72,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <plugins>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>io.smallrye</groupId>
-        <artifactId>jandex-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-      </plugin>
-
-    </plugins>
-  </build>
-
 </project>


### PR DESCRIPTION
this should be removed as the parent pom is an aggregator and doesn't contain any source code to compile